### PR TITLE
sepolicy: Allow platform_app to use nfc_service for NFC tile

### DIFF
--- a/private/platform_app.te
+++ b/private/platform_app.te
@@ -59,6 +59,7 @@ allow platform_app mediaserver_service:service_manager find;
 allow platform_app mediametrics_service:service_manager find;
 allow platform_app mediaextractor_service:service_manager find;
 allow platform_app mediadrmserver_service:service_manager find;
+allow platform_app nfc_service:service_manager find;
 allow platform_app persistent_data_block_service:service_manager find;
 allow platform_app radio_service:service_manager find;
 allow platform_app thermal_service:service_manager find;


### PR DESCRIPTION
This is already permitted for priv_app and even untrusted_app.

Change-Id: I02fe4411c2c9acd1b907028e5e2f019a74788133